### PR TITLE
add deleted metrics

### DIFF
--- a/metrics/allowlist/custom-metrics-allowlist.yaml
+++ b/metrics/allowlist/custom-metrics-allowlist.yaml
@@ -7,3 +7,4 @@ data:
   metrics_list.yaml: |
     names:
       - node_memory_Active_bytes
+      - rest_client_requests_total-


### PR DESCRIPTION
if a metric name ending in `-`,  we will delete this metric from the default allowlist.

https://github.com/open-cluster-management/backlog/issues/12106

Signed-off-by: Song Song Li <ssli@redhat.com>